### PR TITLE
added logic for latest

### DIFF
--- a/DSCResources/cProjectDeploy/cProjectDeploy.psm1
+++ b/DSCResources/cProjectDeploy/cProjectDeploy.psm1
@@ -47,7 +47,12 @@ function Invoke-InitialDeploy{
     pushd "$($env:SystemDrive)\Octopus\OctopusTools\"
     foreach ($environment in $environments){
         Write-Verbose "Deploying Project $Project to environment $environment"
-        $deployArguments = @("deploy-release", "--project", $Project, "--deployto", $environment, "--releaseNumber", $Version, "--specificmachines", $env:COMPUTERNAME, "--server", $octopusServerUrl, "--apiKey", $apiKey)
+        if($Version -eq 'latest') {
+            $deployArguments = @("deploy-release", "--project", $Project, "--deployto", $environment, "--releaseNumber", $Version, "--specificmachines", $env:COMPUTERNAME, "--server", $octopusServerUrl, "--apiKey", $apiKey)
+        }
+        else {
+            $deployArguments = @("deploy-release", "--project", $Project, "--deployto", $environment, "--version=latest", "--specificmachines", $env:COMPUTERNAME, "--server", $octopusServerUrl, "--apiKey", $apiKey)
+        }
         if ($Wait){
             $deployArguments += "--waitfordeployment"
         }


### PR DESCRIPTION
Added logic to use --version=latest as described in http://docs.octopusdeploy.com/display/OD/Deploying+releases 

--releaseNumber, --version=VALUE
        Version number of the release to deploy. Or
        specify --version=latest for the latest release.
